### PR TITLE
Add support for ephemeralContainers

### DIFF
--- a/approvals/kir_test.TestKind.Pod.approved.txt
+++ b/approvals/kir_test.TestKind.Pod.approved.txt
@@ -1,2 +1,3 @@
 nginx
 gcr.io/google-containers/sidecar
+busybox:1.28

--- a/approvals/kir_test.TestKind.Pod.input.yaml
+++ b/approvals/kir_test.TestKind.Pod.input.yaml
@@ -12,3 +12,7 @@ spec:
     - name: init-mysidecar
       image: gcr.io/google-containers/sidecar
       restartPolicy: Always
+  ephemeralContainers:
+    - name: debugger
+      image: busybox:1.28
+      targetContainerName: myapp

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -47,5 +47,8 @@ func GetContainersFromObject(obj interface{}) ([]corev1.Container, error) {
 	var containers []corev1.Container
 	containers = append(containers, podSpec.Containers...)
 	containers = append(containers, podSpec.InitContainers...)
+	for _, ec := range podSpec.EphemeralContainers {
+		containers = append(containers, corev1.Container(ec.EphemeralContainerCommon))
+	}
 	return containers, nil
 }

--- a/k8s/k8s_test.go
+++ b/k8s/k8s_test.go
@@ -221,6 +221,33 @@ func TestGetContainersFromObject(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Pod with ephemeral container",
+			obj: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "container1", Image: "image1"},
+					},
+					InitContainers: []corev1.Container{
+						{Name: "init-container1", Image: "init-image1"},
+					},
+					EphemeralContainers: []corev1.EphemeralContainer{
+						{
+							EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+								Name:  "debugger",
+								Image: "ephemeral-image1",
+							},
+						},
+					},
+				},
+			},
+			want: []corev1.Container{
+				{Name: "container1", Image: "image1"},
+				{Name: "init-container1", Image: "init-image1"},
+				{Name: "debugger", Image: "ephemeral-image1"},
+			},
+			wantErr: false,
+		},
+		{
 			name:    "Invalid",
 			obj:     "invalid",
 			want:    nil,

--- a/yamlparser/yamlparser_test.go
+++ b/yamlparser/yamlparser_test.go
@@ -32,3 +32,39 @@ spec:
 		}
 	}
 }
+
+func TestProcessDataEphemeralContainers(t *testing.T) {
+	data := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: test-container
+    image: test-image
+  initContainers:
+  - name: init-container
+    image: init-image
+  ephemeralContainers:
+  - name: debugger
+    image: ephemeral-image
+    targetContainerName: test-container
+`
+
+	images, err := ProcessData([]byte(data))
+	if err != nil {
+		t.Fatalf("ProcessData() error = %v", err)
+	}
+
+	expected := []string{"test-image", "init-image", "ephemeral-image"}
+	if len(images) != len(expected) {
+		t.Fatalf("expected %d images, got %d: %v", len(expected), len(images), images)
+	}
+
+	for i, img := range images {
+		if img != expected[i] {
+			t.Errorf("expected image %q, got %q", expected[i], img)
+		}
+	}
+}


### PR DESCRIPTION
## What

Collects OCI images from a pod's `ephemeralContainers` in addition to `containers` and `initContainers`.

## Why

`kir` previously ignored `ephemeralContainers`, so images injected via `kubectl debug` (or otherwise present in a manifest's ephemeral container list) were silently missing from the output. For a tool whose purpose is enumerating every image a pod would run — e.g. to feed a vulnerability scanner — that's a coverage gap.

## How

`GetContainersFromObject` in `k8s/k8s.go` now walks `podSpec.EphemeralContainers`. Because `EphemeralContainerCommon` is a direct type definition of `corev1.Container`, each entry converts cleanly without copying fields:

```go
for _, ec := range podSpec.EphemeralContainers {
    containers = append(containers, corev1.Container(ec.EphemeralContainerCommon))
}
```

Nothing else needed changing — `EphemeralContainers` already rides along on the `PodSpec` for every supported kind (Pod, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, CronJob), and everything downstream is generic over `[]corev1.Container`.

## Tests

- `k8s/k8s_test.go`: new table case asserting an ephemeral container's image is collected alongside regular and init containers.
- `yamlparser/yamlparser_test.go`: round-trip test that decodes a Pod manifest with `ephemeralContainers` from YAML and confirms all three image sources come through, exercising the deserializer path end-to-end.

`go build ./...` and `go test ./...` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YcWYpbf4mF49SYnbkf28b

---
_Generated by [Claude Code](https://claude.ai/code/session_013YcWYpbf4mF49SYnbkf28b)_