### PR TITLE
Use the any alias instead of interface{}

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GetPodSpec extracts the PodSpec from a Kubernetes object
-func GetPodSpec(obj interface{}) (*corev1.PodSpec, error) {
+func GetPodSpec(obj any) (*corev1.PodSpec, error) {
 	switch resource := obj.(type) {
 	case *corev1.Pod:
 		return &resource.Spec, nil
@@ -38,7 +38,7 @@ func GetContainerImages(containers []corev1.Container) []string {
 	return images
 }
 
-func GetContainersFromObject(obj interface{}) ([]corev1.Container, error) {
+func GetContainersFromObject(obj any) ([]corev1.Container, error) {
 	podSpec, err := GetPodSpec(obj)
 	if err != nil {
 		return nil, err

--- a/k8s/k8s_test.go
+++ b/k8s/k8s_test.go
@@ -12,7 +12,7 @@ import (
 func TestGetPodSpec(t *testing.T) {
 	tests := []struct {
 		name    string
-		obj     interface{}
+		obj     any
 		wantErr bool
 	}{
 		{"Pod", &corev1.Pod{}, false},
@@ -75,7 +75,7 @@ func TestGetPodSpecSupported(t *testing.T) {
 
 	tests := []struct {
 		name string
-		obj  interface{}
+		obj  any
 	}{
 		{"Deployment", &appsv1.Deployment{
 			Spec: appsv1.DeploymentSpec{
@@ -176,7 +176,7 @@ func TestGetContainerImages(t *testing.T) {
 func TestGetContainersFromObject(t *testing.T) {
 	tests := []struct {
 		name    string
-		obj     interface{}
+		obj     any
 		want    []corev1.Container
 		wantErr bool
 	}{


### PR DESCRIPTION
## What
Replace `interface{}` with `any` in the `k8s` package (`GetPodSpec`, `GetContainersFromObject`, and the test tables).

## Why
`any` has been the idiomatic spelling of `interface{}` since Go 1.18; the module targets Go 1.24.

## Behavior change
None — purely cosmetic. Standalone, no overlap with other PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pc6NAURAqjU4LYJx93tgSC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pc6NAURAqjU4LYJx93tgSC)_