### PR TITLE
Harden CI: download deps, check fmt/vet/tidy, race tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,25 @@ jobs:
         with:
           go-version: ${{ steps.go-version.outputs.go-version }}
 
-      - name: Install dependencies
-        run: go mod tidy
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-ed:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Verify go.mod and go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
 
       - name: Run tests
-        run: go test ./...
+        run: go test -race ./...


### PR DESCRIPTION
## What
Strengthen the `Go Test` workflow.

- Install deps with `go mod download` (non-mutating) instead of `go mod tidy`.
- Fail the build on non-`gofmt`-ed files and on `go vet` findings.
- Verify `go.mod`/`go.sum` are tidy via `go mod tidy` + `git diff --exit-code`.
- Run tests with `-race`.

## Why
The workflow ran `go mod tidy` as its dependency step, which mutates `go.mod`/`go.sum` inside CI and would **hide** an untidy module rather than catch it. It also ran no formatting, vet, or race checks.

## Notes
All new steps were validated locally against `master`: fmt/vet clean, module already tidy, `-race` green. Standalone, no overlap with other PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pc6NAURAqjU4LYJx93tgSC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pc6NAURAqjU4LYJx93tgSC)_