### PR TITLE
Point README examples at the manifests that exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@
 ### Get images for a manifest:
 
 ```shell
-$ go run main.go examples/statefulset.yaml
+$ go run main.go approvals/kir_test.TestKind.StatefulSet.input.yaml
 registry.k8s.io/nginx-slim:0.8
 gcr.io/google-containers/sidecar
 kiwigrid/k8s-sidecar
 ```
 
-### Get images for all manifests in a folder:
+### Get images for all manifests matching a glob:
 
 ```shell
-$ go run main.go examples/* | sort -u
+$ go run main.go approvals/kir_test.TestKind.*.input.yaml | sort -u
 busybox:1.28
 gcr.io/google-containers/busybox
 gcr.io/google-containers/sidecar
@@ -55,11 +55,11 @@ $ kubectl get pod -A -o yaml | go run main.go - | sort -u
 
 ```shell
 # Syft:
-$ go run main.go examples/job.yaml | xargs syft
+$ go run main.go approvals/kir_test.TestKind.Job.input.yaml | xargs syft
 
 # Snyk:
-$ go run main.go examples/job.yaml | xargs snyk container test
+$ go run main.go approvals/kir_test.TestKind.Job.input.yaml | xargs snyk container test
 
 # Docker Scout
-$ go run main.go examples/job.yaml | xargs docker scout cves
+$ go run main.go approvals/kir_test.TestKind.Job.input.yaml | xargs docker scout cves
 ```


### PR DESCRIPTION
## What
Fix the README's usage section, which referenced an `examples/` directory that was never in the repo — so every documented command failed for anyone following along.

Rather than add a duplicate set of manifests, point the commands at the existing approval-test fixtures under `approvals/`, which are already the canonical sample manifests.

## Result
Outputs match what the README documents:
- `kir approvals/kir_test.TestKind.StatefulSet.input.yaml` prints the three listed images.
- `kir approvals/kir_test.TestKind.*.input.yaml | sort -u` prints the listed seven.

## Scope
README-only — no code, test, or fixture changes. Fully standalone; no overlap with any other PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pc6NAURAqjU4LYJx93tgSC