### PR TITLE
Add a testable Run(...) int CLI entry point

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,36 +2,60 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"log"
+	"strings"
 
 	"github.com/mpv/kir/fileutil"
 	"github.com/mpv/kir/processor"
 )
 
-func Execute(args []string) {
-	if len(args) == 1 && args[0] == "-" {
-		images, err := processor.ProcessStdin()
-		if err != nil {
-			log.Fatalf("error: %v", err)
-		}
-		printImages(images)
-		return
+// Run executes the kir CLI and returns the process exit code. A single "-"
+// argument reads a manifest stream from stdin; otherwise the arguments are
+// treated as files, directories, or globs. Images are written to stdout and
+// errors to stderr.
+//
+// Run performs no os.Exit and touches neither os.Stdin/os.Stdout/os.Stderr nor
+// the global logger, so the whole CLI contract — argv and stdin in, and stdout,
+// stderr, and exit code out — is exercised by an in-process call.
+func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	logger := log.New(stderr, "", 0)
+
+	if len(args) == 0 {
+		logger.Print("Usage: kir <file_path> [<file_path_2> ...] or kir -")
+		return 1
 	}
+
+	if len(args) == 1 && args[0] == "-" {
+		if stdin == nil {
+			stdin = strings.NewReader("")
+		}
+		images, err := processor.ProcessStdin(stdin)
+		if err != nil {
+			logger.Printf("error: %v", err)
+			return 1
+		}
+		printImages(stdout, images)
+		return 0
+	}
+
 	files, err := fileutil.FindFiles(args)
 	if err != nil {
-		log.Fatalf("error: %v", err)
+		logger.Printf("error: %v", err)
+		return 1
 	}
 	for _, filePath := range files {
 		images, err := processor.ProcessFile(filePath)
 		if err != nil {
-			log.Printf("error: %v", err)
+			logger.Printf("error: %v", err)
 		}
-		printImages(images)
+		printImages(stdout, images)
 	}
+	return 0
 }
 
-func printImages(images []string) {
+func printImages(w io.Writer, images []string) {
 	for _, image := range images {
-		fmt.Println(image)
+		fmt.Fprintln(w, image)
 	}
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2,16 +2,13 @@ package cmd
 
 import (
 	"bytes"
-	"log"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
-func TestExecuteFile(t *testing.T) {
-	dir := setupTestDir(t)
-	defer os.RemoveAll(dir)
-
-	createTestFile(dir, "test.yaml", `
+const podManifest = `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -20,109 +17,52 @@ spec:
   containers:
   - name: test-container
     image: test-image
-`)
+`
 
-	testCases := []struct {
-		args           []string
-		expectedOutput string
-	}{
-		{[]string{"test.yaml"}, "test-image\n"},
+func TestRunFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.yaml")
+	if err := os.WriteFile(path, []byte(podManifest), 0644); err != nil {
+		t.Fatal(err)
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.args[0], func(t *testing.T) {
-			oldStdout := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{path}, nil, &stdout, &stderr)
 
-			os.Args = append([]string{"cmd"}, tc.args...)
-			Execute(tc.args)
-
-			w.Close()
-			os.Stdout = oldStdout
-
-			var buf bytes.Buffer
-			_, err := buf.ReadFrom(r)
-			if err != nil {
-				t.Fatalf("Error reading from buffer: %v", err)
-			}
-			output := buf.String()
-
-			if output != tc.expectedOutput {
-				t.Errorf("expected %q, got %q", tc.expectedOutput, output)
-			}
-		})
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if got, want := stdout.String(), "test-image\n"; got != want {
+		t.Errorf("stdout = %q, want %q", got, want)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty", stderr.String())
 	}
 }
 
-func TestExecuteStdin(t *testing.T) {
-	testCases := []struct {
-		args           []string
-		input          string
-		expectedOutput string
-	}{
-		{[]string{"-"}, `
-apiVersion: v1
-kind: Pod
-metadata:
-  name: test-pod
-spec:
-  containers:
-  - name: test-container
-    image: test-image
-`, "test-image\n"},
+func TestRunStdin(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-"}, strings.NewReader(podManifest), &stdout, &stderr)
+
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
 	}
-
-	for _, tc := range testCases {
-		t.Run(tc.args[0], func(t *testing.T) {
-			oldStdout := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
-
-			oldStdin := os.Stdin
-			stdinR, stdinW, _ := os.Pipe()
-			os.Stdin = stdinR
-			stdinW.Write([]byte(tc.input))
-			stdinW.Close()
-
-			os.Args = append([]string{"cmd"}, tc.args...)
-			Execute(tc.args)
-
-			w.Close()
-			os.Stdout = oldStdout
-			os.Stdin = oldStdin
-
-			var buf bytes.Buffer
-			_, err := buf.ReadFrom(r)
-			if err != nil {
-				t.Fatalf("Error reading from buffer: %v", err)
-			}
-			output := buf.String()
-
-			if output != tc.expectedOutput {
-				t.Errorf("expected %q, got %q", tc.expectedOutput, output)
-			}
-		})
+	if got, want := stdout.String(), "test-image\n"; got != want {
+		t.Errorf("stdout = %q, want %q", got, want)
 	}
 }
 
-func setupTestDir(t *testing.T) string {
-	dir, err := os.MkdirTemp("", "test")
-	if err != nil {
-		t.Fatalf("error: %v", err)
+func TestRunNoArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run(nil, nil, &stdout, &stderr)
+
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
 	}
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatalf("error: %v", err)
+	if !strings.Contains(stderr.String(), "Usage") {
+		t.Errorf("stderr = %q, want it to mention usage", stderr.String())
 	}
-
-	return dir
-}
-
-func createTestFile(dir, name, content string) {
-	err := os.WriteFile(dir+"/"+name, []byte(content), 0644)
-	if err != nil {
-		log.Fatalf("error: %v", err)
+	if stdout.Len() != 0 {
+		t.Errorf("stdout = %q, want empty", stdout.String())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,21 +1,11 @@
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/mpv/kir/cmd"
 )
 
-func init() {
-	log.SetFlags(0) // Disable timestamps in log output
-}
-
 func main() {
-	if len(os.Args) < 2 {
-		log.Fatal("Usage: kir <file_path> [<file_path_2> ...] or kir -")
-		return
-	}
-
-	cmd.Execute(os.Args[1:])
+	os.Exit(cmd.Run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -10,18 +9,13 @@ import (
 	"github.com/mpv/kir/yamlparser"
 )
 
-func ProcessStdin() ([]string, error) {
-	reader := bufio.NewReader(os.Stdin)
-	var data []byte
-	for {
-		line, err := reader.ReadBytes('\n')
-		if err != nil && err != io.EOF {
-			return nil, fmt.Errorf("error reading stdin: %v", err)
-		}
-		data = append(data, line...)
-		if err == io.EOF {
-			break
-		}
+// ProcessStdin reads a manifest stream from r and returns its images. Taking an
+// io.Reader (rather than reading os.Stdin directly) keeps it testable and lets
+// the CLI inject stdin.
+func ProcessStdin(r io.Reader) ([]string, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("error reading stdin: %v", err)
 	}
 	return yamlparser.ProcessData(data)
 }


### PR DESCRIPTION
## What
Replace `cmd.Execute(args)` with a single testable entry point:

```go
func Run(args []string, stdin io.Reader, stdout, stderr io.Writer) int
func main() { os.Exit(cmd.Run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr)) }
```

`Run` resolves the arguments, writes images to the injected `stdout`, reports errors to the injected `stderr` (via a local `log.New(stderr, "", 0)` rather than the global logger), and **returns the exit code**. `processor.ProcessStdin` now takes an `io.Reader` so stdin is injectable too.

## Why
The CLI's observable contract — argv + stdin → **stdout, stderr, exit code** — could not be asserted in-process: `Execute` wrote to `os.Stdout`, read `os.Stdin`, and exited via `log.Fatal`. Tests had to hijack `os.Stdout`/`os.Args`. Making the exit code a returned value and the streams injected parameters means the whole triple is now assertable from a plain function call — the enabler for keeping the e2e/triple goldens in `approvals/` in-process (no subprocess, no `go build`).

## Behavior change
**None — verified byte-for-byte.** Built the binary and compared against master across every scenario: single file, multi-document file, stdin, unsupported kind (stderr + exit 0), missing path (silent + exit 0), and no-args usage (stderr + exit 1). Identical stdout/stderr/exit in all cases.

The cmd tests are rewritten to call `Run` with `bytes.Buffer`s and assert the triple directly — no `os.Stdout`/`os.Stdin`/`os.Args` swapping, no `chdir`.

## Relationship to the open CLI stack
This **supersedes #50** (`Execute(args, out io.Writer) error`): `Run` is the fuller version — it returns an exit code and injects stdin/stderr as well. The *behavior* changes in the other open PRs are orthogonal and would layer cleanly on top of `Run` rather than on `Execute`:
- #55 (exit non-zero on file failure) → have the per-file loop count failures and `return 1`.
- #57 (error on missing path) → unchanged (`fileutil`).
- #49 (stdin multi-doc) / #54 (skip non-workloads) → unchanged (`processor`/`yamlparser`).

If you adopt `Run`, the cleanest path is to close/rework #50 and re-base #55 onto this shape — say the word and I'll reorganize that stack. No dependency change; `-race`/`vet`/`gofmt`/`go mod tidy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pc6NAURAqjU4LYJx93tgSC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pc6NAURAqjU4LYJx93tgSC)_