### PR TITLE
ci: enable Conventional Commits in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,15 @@
   ],
   "postUpdateOptions": [
     "gomodTidy"
+  ],
+  "semanticCommits": "enabled",
+  "packageRules": [
+    {
+      "description": "CI-only bumps (GitHub Actions) use a non-releasing type so they don't cut a release; go modules and the Docker base image stay fix -> patch since they change the shipped artifact.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "semanticCommitType": "ci"
+    }
   ]
 }


### PR DESCRIPTION
## What

Teach Renovate the Conventional Commits convention that release-please now relies on, so dependency PRs carry a classifiable type instead of plain `Update X` messages.

```json
"semanticCommits": "enabled",
"packageRules": [
  { "matchManagers": ["github-actions"], "semanticCommitType": "ci" }
]
```

## Behaviour

With `config:best-practices`' `:semanticPrefixFixDepsChoreOthers`, once semantic commits are enabled dependency updates default to `fix(deps):`. Combined with the override:

| Renovate manager | Commit type | Release? |
|------------------|-------------|----------|
| Go modules (`go.mod`) | `fix(deps):` | patch — the shipped binary changed |
| Docker base image (`Dockerfile`) | `fix(deps):` | patch — the shipped image changed |
| Go toolchain (`.tool-versions`) | `fix(deps):` | patch — rebuilds the binary |
| **GitHub Actions** (`.github/workflows`) | **`ci(deps):`** | **none** — CI tooling only |

The `github-actions` override is the one judgment call: a CI-action bump doesn't change what users run, so it shouldn't cut a user-facing release. Flip it to `fix` if you'd rather every dependency bump release.

## Existing Renovate PRs

Open Renovate PRs (#42/#43/#45/#47) were created before this and still have non-conventional titles. Once this lands, Renovate re-titles them conventionally on their next rebase/refresh — or they can be merged as-is (they're action bumps, which we don't want to release anyway, so release-please correctly ignoring them is fine).

## Note

This is a fresh follow-up PR on the (post-merge) designated branch — not a reopen of #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RJcNXwJdwhtEgsfLfYKtv

---
_Generated by [Claude Code](https://claude.ai/code/session_016RJcNXwJdwhtEgsfLfYKtv)_