### PR TITLE
ci: pin cosign to v2.4.3 so release signing works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,12 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # cosign 2.5.0 made sign-blob default to the new Sigstore bundle
+          # format, which ignores the --output-signature/--output-certificate
+          # flags GoReleaser passes and then aborts. Pin to the last 2.4.x until
+          # the .goreleaser.yaml signing config is migrated to --bundle.
+          cosign-release: v2.4.3
 
       - name: Install syft (for SBOMs)
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0


### PR DESCRIPTION
## What

Fixes the failure on the first real release run (`v0.3.0`). GoReleaser built binaries, SBOMs, and checksums successfully, then aborted at signing:

```
signing dist/checksums.txt: create bundle file: open : no such file or directory
release failed ... could not sign artifact  cmd=cosign  artifact=checksums.txt
```

with the tell:

```
Flag --output-signature has been deprecated ... will be ignored (using --new-bundle-format)
```

## Why

`cosign-installer` pulled a **cosign ≥ 2.5.0**, and 2.5.0 changed `sign-blob` to default to the new Sigstore **bundle** format — which ignores the `--output-signature`/`--output-certificate` flags in `.goreleaser.yaml` and then fails because no `--bundle` path is set.

## Fix

Pin cosign to the last 2.4.x (**v2.4.3**) via `cosign-installer`'s `cosign-release` input, so the existing, proven signing config produces the `.sig`/`.pem` detached artifacts again. Renovate's github-actions manager tracks the action digest, not this input, so it won't silently bump it back.

Typed `ci:` — release tooling, non-releasing.

## Getting binaries onto a release

- **`v0.3.0` itself** already published its tag + release + changelog, just without assets; re-running against that tag would use the *old* config in the tag's tree, so it stays asset-less (an early tag — fine to leave, or backfill locally).
- **Next release** picks up this fix automatically: merging any pending `fix:`/`feat:` (e.g. the #49–#57 stack) → release-please cuts the next version → GoReleaser signs and attaches binaries + image.

## Follow-up (separate, testable)

Migrate the `.goreleaser.yaml` `signs` block to the modern `--bundle` format so we can un-pin cosign and stay current — validated with `goreleaser release --skip=publish --clean` before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RJcNXwJdwhtEgsfLfYKtv

---
_Generated by [Claude Code](https://claude.ai/code/session_016RJcNXwJdwhtEgsfLfYKtv)_