### PR TITLE
ci: temporarily hold release signing to unblock artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,29 +71,37 @@ docker_manifests:
       - "ghcr.io/mpv/kir:{{ .Version }}-amd64"
       - "ghcr.io/mpv/kir:{{ .Version }}-arm64"
 
-# Keyless (Sigstore) signing of the checksums file — covers every binary/archive.
-signs:
-  - cmd: cosign
-    signature: "${artifact}.sig"
-    certificate: "${artifact}.pem"
-    args:
-      - sign-blob
-      - "--yes"
-      - "--output-signature=${signature}"
-      - "--output-certificate=${certificate}"
-      - "${artifact}"
-    artifacts: checksum
-    output: true
-
-# Keyless (Sigstore) signing of the published multi-arch image manifests.
-docker_signs:
-  - cmd: cosign
-    args:
-      - sign
-      - "--yes"
-      - "${artifact}"
-    artifacts: manifests
-    output: true
+# Signing is temporarily held so the release job can go green and start
+# publishing binaries + image + SBOMs + checksums. cosign >= 2.5.0 changed
+# sign-blob to the new bundle format, which broke the config below (the flags
+# are ignored and it aborts). Restore signing via one of:
+#   - pin cosign to 2.4.x and keep this config (see PR #70), or
+#   - roll forward: migrate to `--bundle` and un-pin cosign.
+# TODO(signing): re-enable once the approach is chosen and validated in CI.
+#
+# # Keyless (Sigstore) signing of the checksums file — covers every binary/archive.
+# signs:
+#   - cmd: cosign
+#     signature: "${artifact}.sig"
+#     certificate: "${artifact}.pem"
+#     args:
+#       - sign-blob
+#       - "--yes"
+#       - "--output-signature=${signature}"
+#       - "--output-certificate=${certificate}"
+#       - "${artifact}"
+#     artifacts: checksum
+#     output: true
+#
+# # Keyless (Sigstore) signing of the published multi-arch image manifests.
+# docker_signs:
+#   - cmd: cosign
+#     args:
+#       - sign
+#       - "--yes"
+#       - "${artifact}"
+#     artifacts: manifests
+#     output: true
 
 # release-please owns the changelog and the GitHub Release body; GoReleaser only
 # uploads artifacts to the release it already created for the tag.


### PR DESCRIPTION
## What

Comment out the `signs` and `docker_signs` blocks in `.goreleaser.yaml` so the release job goes **green** and starts publishing artifacts. This decouples *"does the pipeline deliver?"* from *"is signing configured exactly right?"* — the former is essentially proven, the latter is the fiddly part.

## Why

On the first real release (`v0.3.0`), GoReleaser built the binaries, SBOMs, checksums, and image successfully, then aborted at cosign:

```
signing dist/checksums.txt: create bundle file: open : no such file or directory
```

cosign ≥ 2.5.0 made `sign-blob` default to the new Sigstore bundle format, which ignores the `--output-signature`/`--output-certificate` flags and fails. So `v0.3.0` got a tag + release + changelog but **no assets**.

## Effect

Next release publishes the full set — multi-platform **binaries**, archives, **SBOMs**, `checksums.txt`, and the multi-arch **image** at `ghcr.io/mpv/kir` — just **unsigned**. For a 0.x tool bootstrapping releases, shipping SBOM'd + checksummed artifacts now with signatures as a fast follow is a reasonable trade; signing is additive hardening, not a blocker.

The `Install cosign` step and `id-token: write` permission are left in place, and the signing config is commented (not deleted) with a `TODO`, so restoring it is a one-block uncomment.

## Restoring signing (follow-up, pick one)

- **Pin** cosign to 2.4.x and keep the existing config — [#70](https://github.com/MPV/kir/pull/70).
- **Roll forward** to the `--bundle` format and keep cosign current.

Either way, validated with a `workflow_dispatch` dry-run (`goreleaser release --skip=publish`) in CI before it gates a real release.

Typed `ci:` — release tooling, non-releasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RJcNXwJdwhtEgsfLfYKtv

---
_Generated by [Claude Code](https://claude.ai/code/session_016RJcNXwJdwhtEgsfLfYKtv)_