### PR TITLE
fix: publish signed release artifacts (cosign v3 bundle format)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,37 +71,28 @@ docker_manifests:
       - "ghcr.io/mpv/kir:{{ .Version }}-amd64"
       - "ghcr.io/mpv/kir:{{ .Version }}-arm64"
 
-# Signing is temporarily held so the release job can go green and start
-# publishing binaries + image + SBOMs + checksums. cosign >= 2.5.0 changed
-# sign-blob to the new bundle format, which broke the config below (the flags
-# are ignored and it aborts). Restore signing via one of:
-#   - pin cosign to 2.4.x and keep this config (see PR #70), or
-#   - roll forward: migrate to `--bundle` and un-pin cosign.
-# TODO(signing): re-enable once the approach is chosen and validated in CI.
-#
-# # Keyless (Sigstore) signing of the checksums file — covers every binary/archive.
-# signs:
-#   - cmd: cosign
-#     signature: "${artifact}.sig"
-#     certificate: "${artifact}.pem"
-#     args:
-#       - sign-blob
-#       - "--yes"
-#       - "--output-signature=${signature}"
-#       - "--output-certificate=${certificate}"
-#       - "${artifact}"
-#     artifacts: checksum
-#     output: true
-#
-# # Keyless (Sigstore) signing of the published multi-arch image manifests.
-# docker_signs:
-#   - cmd: cosign
-#     args:
-#       - sign
-#       - "--yes"
-#       - "${artifact}"
-#     artifacts: manifests
-#     output: true
+# Keyless (Sigstore) signing of the checksums file — one bundle (.sigstore.json)
+# covers every binary/archive. See CONTRIBUTING.md for how to verify a release.
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
+# Keyless (Sigstore) signing of the published multi-arch image manifests.
+docker_signs:
+  - cmd: cosign
+    args:
+      - sign
+      - "--yes"
+      - "${artifact}"
+    artifacts: manifests
+    output: true
 
 # release-please owns the changelog and the GitHub Release body; GoReleaser only
 # uploads artifacts to the release it already created for the tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,23 @@ Versioning is driven by
 
 `kir --version` prints the embedded version, commit, and build date.
 
+### Verifying a release
+
+Binaries are signed keylessly; the signature is a Sigstore bundle
+(`checksums.txt.sigstore.json`) covering `checksums.txt`:
+
+```shell
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/mpv/kir/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
+```
+
+Then check a downloaded binary's archive against `checksums.txt`. The container
+image is signed too: `cosign verify ghcr.io/mpv/kir:X.Y.Z` (with the same
+identity flags).
+
 Dependency updates are managed by [Renovate](https://docs.renovatebot.com/),
 which follows the same commit conventions, so routine bumps flow through the same
 process.


### PR DESCRIPTION
## What

Repairs release signing so a release actually ships artifacts — and does it as a **releasable `fix:`** so merging this cuts **v0.3.1** and gets the first signed binaries out. `v0.3.0` tagged/released but published **nothing** because signing aborted.

## Root cause

`cosign-installer` pulls **cosign v3**, which removed `sign-blob`'s `--output-signature`/`--output-certificate` flags in favour of a single Sigstore **bundle**. The old config aborted:

```
signing dist/checksums.txt: create bundle file: open : no such file or directory
```

## Fix

```yaml
signs:
  - cmd: cosign
    signature: "${artifact}.sigstore.json"
    args: [sign-blob, "--bundle=${signature}", "${artifact}", "--yes"]
    artifacts: checksum
    output: true
```

One `checksums.txt.sigstore.json` bundle (sig + cert + Rekor proof), covering every binary via `checksums.txt`. Verified against **Sigstore's own `.goreleaser.yml`** and **GoReleaser's cosign v3 guidance** ([#6195](https://github.com/goreleaser/goreleaser/issues/6195)). cosign stays current — no pin. `docker_signs` (`cosign sign --yes`) is unchanged (image signing wasn't affected). Verify instructions added to `CONTRIBUTING.md`.

## On the `fix:` type

Strictly a `.goreleaser.yaml` change is `ci:`/`build:`, but `v0.3.0`'s release is defective from a user's view (no downloadable/signed artifacts). Typing this `fix:` is the honest, practical framing — the user-facing effect is "signed binaries now publish" — and it's what makes merging this produce the release you want.

## Result

Merge this → release-please opens a **v0.3.1** Release PR → merge that → GoReleaser runs the fixed config → **first fully signed release** (binaries + `.sigstore.json` + image + SBOMs).

## Supersedes

[#70](https://github.com/MPV/kir/pull/70) (pin cosign) and [#71](https://github.com/MPV/kir/pull/71) (hold signing) — both can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RJcNXwJdwhtEgsfLfYKtv