### PR TITLE
ci: don't cut releases for test-only dependency bumps

### DIFF
--- a/docs/adr/0006-conventional-commits-and-releases.md
+++ b/docs/adr/0006-conventional-commits-and-releases.md
@@ -8,7 +8,10 @@ Commit messages and PR titles follow
 derives the version and `CHANGELOG.md` from commit types on `master`; GoReleaser
 builds and publishes artifacts. `fix:`/`perf:` → patch, `feat:` → minor,
 `feat!:`/`BREAKING CHANGE:` → major; `ci|build|docs|refactor|test|chore` → none.
-Renovate emits `fix(deps):`/`ci(deps):`.
+Renovate follows the same convention, typed by whether an update can reach
+users: `fix(deps):` for Go modules compiled into the binary, `ci(deps):` for
+GitHub Actions, and `chore(deps):` for everything that cannot (test-only
+modules, the local `Dockerfile`'s builder image, the pinned toolchain).
 
 No manual release steps, but a mistyped type mis-classifies a release, and
 squash-merges make the PR title load-bearing.

--- a/renovate.json
+++ b/renovate.json
@@ -9,11 +9,21 @@
   "semanticCommits": "enabled",
   "packageRules": [
     {
-      "description": "CI-only bumps (GitHub Actions) use a non-releasing type so they don't cut a release; go modules and the Docker base image stay fix -> patch since they change the shipped artifact.",
+      "description": "GitHub Actions are CI tooling and never reach the shipped binary or image, so bump them with a non-releasing type.",
       "matchManagers": [
         "github-actions"
       ],
       "semanticCommitType": "ci"
+    },
+    {
+      "description": "go-approval-tests is imported only from _test.go files, so a bump cannot change the shipped binary. go.mod has no test-only dependency type, so Renovate would otherwise default it to fix(deps) and cut a user-facing patch release.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "github.com/approvals/go-approval-tests"
+      ],
+      "semanticCommitType": "chore"
     }
   ]
 }


### PR DESCRIPTION
## What

Route `go-approval-tests` bumps to `chore(deps):` so they stop triggering user-facing releases.

```json
{
  "matchManagers": ["gomod"],
  "matchPackageNames": ["github.com/approvals/go-approval-tests"],
  "semanticCommitType": "chore"
}
```

## Why

`go-approval-tests` is imported **only** from `_test.go` files (`approvals/kir_test.go`) — a bump cannot change the shipped binary. But `go.mod` has no test-only dependency type, so `config:best-practices`' `:semanticPrefixFixDepsChoreOthers` types it `fix(deps):` like any other `require`.

Concretely, open PR [#24](https://github.com/MPV/kir/pull/24) (`fix(deps): update module github.com/approvals/go-approval-tests to v1.14.0`) would cut a patch release whose changelog entry reads *"update module github.com/approvals/go-approval-tests"* — noise for a change no user can observe.

Modules that **are** compiled in (`k8s.io/api`, `apimachinery`, `client-go`) keep `fix(deps):` → patch, e.g. [#66](https://github.com/MPV/kir/pull/66).

## Also in here

- **Corrected the `github-actions` rule's description**, which claimed the Docker base image is `fix` → patch. It isn't — the preset only applies `fix` to the gomod `require` block, so the `Dockerfile` golang tag arrives as `chore(deps):` ([#39](https://github.com/MPV/kir/pull/39)). That's the right outcome anyway: GoReleaser builds the shipped image from `Dockerfile.goreleaser` and compiles with the `go.mod` toolchain, so the builder image only affects local `docker build .`.
- **Updated [ADR 0006](docs/adr/0006-conventional-commits-and-releases.md)**, which recorded "Renovate emits `fix(deps):`/`ci(deps):`", to describe the three-way split now that `chore(deps):` is deliberate.

## Effect on the open Renovate PRs

| PR | Type today | After |
|---|---|---|
| #24 go-approval-tests | `fix(deps):` → patch | **`chore(deps):` → none** |
| #66 kubernetes monorepo | `fix(deps):` → patch | unchanged (correct — it ships) |
| #34, #39 | `chore(deps):` → none | unchanged |
| #40/#42/#43/#45/#47/#67 | `ci(deps):` → none | unchanged |

Existing PRs keep their current titles until Renovate rebases/refreshes them, so #24 would still need a retitle (or just let Renovate recreate it) to pick this up.

Typed `ci:` — release tooling, non-releasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RJcNXwJdwhtEgsfLfYKtv

---
_Generated by [Claude Code](https://claude.ai/code/session_016RJcNXwJdwhtEgsfLfYKtv)_