### PR TITLE
ci: restrict the test workflow token to read-only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - master
 
+# This workflow only reads the checkout — every write belongs to release.yml,
+# which declares its own scopes per job. Stating it here stops the token from
+# inheriting whatever the repository default happens to be.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
One of six independent provenance fixes from a security review of `kir`. Each is on its own branch; none depends on another.

## Problem

`.github/workflows/test.yml` declares no `permissions:` block, so its `GITHUB_TOKEN` is minted with the repository's default scope rather than one the job needs. The job checks out the code, runs `gofmt`, `go vet`, a `go mod tidy` diff, and `go test -race` — none of which write anything.

`release.yml` already gets this right, scoping `contents`, `packages` and `id-token` per job. This just brings the other workflow in line.

## Change

```yaml
permissions:
  contents: read
```

Workflow-level, so it applies to the single `test` job and to any job added later.

## Verification

- `actionlint` clean on the changed file.
- Parsed the result and confirmed `permissions == {contents: read}` with the `test` job still intact.
- No change to what the job runs, so the existing checks are the regression test.

Note that the effect is only visible once merged — a workflow's `permissions` block is read from the version of the file on the target branch for `pull_request` runs, so the check run on this PR still uses the old scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cabg1eqYp3Kx3wcf8gxRc8)_