### PR TITLE
build: pin base images by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24@sha256:d2d2bc1c84f7e60d7d2438a3836ae7d0c847f4888464e7ec9ba3a1339a1ee804 AS builder
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -13,7 +13,7 @@ COPY yamlparser/ yamlparser/
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o kir main.go
 
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
 WORKDIR /
 COPY --from=builder /workspace/kir .
 USER 65532:65532

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,6 +1,6 @@
 # Build context is assembled by GoReleaser: the pre-built `kir` binary for the
 # target platform is copied in, so there is no build step here.
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
 WORKDIR /
 COPY kir /kir
 USER 65532:65532


### PR DESCRIPTION
One of six independent provenance fixes from a security review of `kir`. Each is on its own branch; none depends on another.

## Problem

Both workflows pin every GitHub Action by commit SHA, but the container base images were still floating tags:

| File | Was |
| --- | --- |
| `Dockerfile` | `golang:1.24` |
| `Dockerfile` | `gcr.io/distroless/static:nonroot` |
| `Dockerfile.goreleaser` | `gcr.io/distroless/static:nonroot` |

Both tags move. Two builds of the same commit can therefore produce different images, and nothing in the release records which base was used — which undercuts the signed-release story the project already invests in.

## Change

Pinned to the digest each tag resolves to today, keeping the tag alongside for readability (the form Renovate itself writes):

- `golang:1.24@sha256:d2d2bc1c84f7e60d7d2438a3836ae7d0c847f4888464e7ec9ba3a1339a1ee804`
- `gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6`

Pinning only helps if something keeps the pins fresh. Renovate's dockerfile manager raises update PRs for digest-pinned `FROM` lines, and `renovate.json` already anticipates base-image bumps flowing through it — so this makes the images *tracked* rather than frozen.

## Verification

Both digests were resolved from the registries and confirmed to be addressable by digest, not just by tag:

- `registry-1.docker.io/v2/library/golang/manifests/sha256:d2d2bc…` → HTTP 200, OCI image index, 16 platforms (so the multi-arch `$BUILDPLATFORM` build is preserved).
- `gcr.io/v2/distroless/static/manifests/sha256:f7f8f7…` → HTTP 200, OCI image index.

Checked that no `FROM` line in either file is left unpinned.

I could not run `docker build` here — no daemon in this environment — so the images themselves were not rebuilt. The change is textual and the digests are the ones the tags currently point at, so a build from this branch should be byte-identical to a build from `master` today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cabg1eqYp3Kx3wcf8gxRc8)_