### PR TITLE
ci: run govulncheck against the module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,3 +52,21 @@ jobs:
 
       - name: Run tests
         run: go test -race ./...
+
+      # kir exists to feed vulnerability scanners, so it should be scanned too.
+      #
+      # go-version-input holds the analysis to the Go this job already derived
+      # from .tool-versions. govulncheck attributes standard-library advisories
+      # to the toolchain it is given, so letting it pick a newer Go than kir is
+      # built with would hide anything fixed upstream but still shipped here.
+      #
+      # cache is off because the steps above have already populated the module
+      # cache; letting the action restore it again just collides with what is
+      # on disk.
+      - name: Check for known vulnerabilities
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
+        with:
+          go-version-input: ${{ steps.go-version.outputs.go-version }}
+          check-latest: false
+          cache: false
+          repo-checkout: false


### PR DESCRIPTION
One of the provenance fixes from a security review of `kir`. Independent of the others. Rebased onto `master` after the dependency merges and the 0.4.3 release.

## Problem

`kir` exists to feed vulnerability scanners, and nothing in CI scanned `kir`. A known advisory in its dependency tree — or in the Go standard library it's built against — would land in a signed release without comment.

That wasn't hypothetical: when this check first ran, it found **8 standard-library vulnerabilities** in the then-pinned Go 1.24.3, the worst needing go1.25.11 to clear. The Go bump to 1.26.5 has since fixed all of them, which is exactly the outcome a gate like this is for.

## Change

One step at the end of the existing Test job:

```yaml
      - name: Check for known vulnerabilities
        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
        with:
          go-version-input: ${{ steps.go-version.outputs.go-version }}
          check-latest: false
          cache: false
          repo-checkout: false
```

**`go-version-input`** is the part worth reviewing. The action defaults to `stable` with `check-latest: true`, which would analyse against whatever Go is newest rather than what this project pins. govulncheck attributes standard-library advisories to the toolchain it's told about, so the default would quietly hide any stdlib vulnerability already fixed upstream but still present in what ships. Reusing the job's existing `steps.go-version` output keeps the scan honest about the released artifact.

`repo-checkout: false` reuses the checkout the job already did; `cache: false` avoids the action's second `setup-go` fighting the module cache the earlier steps already populated (that produced a wall of `tar: … Cannot open: File exists` noise on an earlier run).

## Why the action, and why it works now

An earlier revision of this PR pinned the tool instead — `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...` — because the action installs `govulncheck@latest` internally, and under Go 1.24.3 with `GOTOOLCHAIN=local` that install simply failed:

```
go: golang.org/x/vuln@v1.6.0 requires go >= 1.25.0 (running go 1.24.3; GOTOOLCHAIN=local)
```

That constraint is gone: `.tool-versions` is on **1.26.5**, comfortably past v1.6.0's `go 1.25.0` floor. The action is the better long-term shape, because a `module@version` inside a `run:` block is the one kind of pin Renovate has no manager for — it would have aged silently while every other pin here (Action SHAs, base-image digests) gets update PRs. Now that it builds, it's Renovate-tracked and the scanner stays current on its own.

The residual trade-off, worth knowing: `@latest` means a future govulncheck whose `go` directive outruns this repo's Go will break CI with an install error unrelated to any vulnerability. That's a loud, one-line diagnosis, and preferable to a scanner that quietly rots — but it is the failure mode to expect.

## Verification

CI on this branch is **green**, and for the right reason — the step ran rather than being skipped:

```
Run govulncheck -C "$WORK_DIR" -format "$OUTPUT_FORMAT" "$GO_PACKAGE"
=== Symbol Results ===
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
This scan also found 3 vulnerabilities in packages you import and 6
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
```

The post-job log confirms the analysis toolchain was `/opt/hostedtoolcache/go/1.26.5/x64/bin/go`, i.e. `go-version-input` took effect. No cache noise this run.

Also checked before pushing: `actionlint` clean, and the version floor recomputed against the new `.tool-versions` (1.26.5 ≥ 1.25.0) rather than assumed.

## One loose end, not addressed here

The two workflows still read the Go version from different files — `test.yml` from `.tool-versions` (1.26.5), `release.yml` from `go-version-file: go.mod` (1.26.0). They're within a minor now, so both are past every advisory above and the gap is no longer a security concern. It was a real one when they sat at 1.24.3 and 1.24.1. Worth reconciling to a single source at some point so it can't drift back.