### PR TITLE
docs: add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report privately through GitHub:
+**[Security → Advisories → Report a vulnerability](https://github.com/MPV/kir/security/advisories/new)**.
+
+Please don't open a public issue for something exploitable — the advisory draft
+is private until we publish it, and it gives us a place to work on a fix with
+you.
+
+Include what you'd need yourself: the manifest (or a reduced version of it) that
+triggers the behaviour, the `kir` version from `kir --version`, and what you
+expected instead. A reproducer we can run beats a description we have to
+reconstruct.
+
+`kir` is maintained by volunteers, so we can't promise a response time. We'll
+acknowledge a report as soon as we see it and keep you updated as we work on it.
+
+## What counts as a vulnerability
+
+`kir` decides which images a scanner is asked about. An image it fails to
+report isn't flagged as unscanned — it's never considered, and the scan comes
+back clean. So the reports we most want are the ones where **`kir` under-reports
+without saying so**:
+
+- A manifest whose images `kir` omits from stdout while exiting 0.
+- A document `kir` treats as image-less when it does describe containers.
+- Anything that makes `kir` exit 0 on input it did not fully understand.
+
+Also in scope:
+
+- Output that misrepresents what will be scanned — an image reference that
+  renders as something other than the value passed downstream, or that breaks
+  the newline-separated contract stdout is meant to keep.
+- Input that makes `kir` consume unbounded resources, or read files outside the
+  paths it was given.
+- Anything undermining the integrity of a published release: the signing
+  pipeline, the release workflow, or the container image.
+
+Out of scope: a malformed or unreadable input causing an `error:` on stderr and
+a non-zero exit. That is the designed behaviour — see
+[ADR 0008](docs/adr/0008-best-effort-processing-and-exit-codes.md).
+
+## Supported versions
+
+`kir` is pre-1.0 and releases roll forward. Fixes go into the next release from
+`master`; there are no maintenance branches for older versions. Report against
+the [latest release](https://github.com/MPV/kir/releases/latest) where you can.
+
+## Verifying a release
+
+Binaries and container images are signed keylessly with
+[cosign](https://github.com/sigstore/cosign). `CONTRIBUTING.md` has the
+[verification commands](CONTRIBUTING.md#verifying-a-release) — worth running
+before you trust a downloaded artifact, and worth telling us about if they
+fail.


### PR DESCRIPTION
One of six independent provenance fixes from a security review of `kir`. Each is on its own branch; none depends on another.

## Problem

No `SECURITY.md`, so someone who found a way to make `kir` under-report images had no private channel to say so — the only route was a public issue, which is the wrong place for anything exploitable. It's also an OpenSSF Scorecard check, and it's table stakes for a tool that runs inside other people's security pipelines.

## Change

Adds `SECURITY.md` pointing at GitHub's private vulnerability reporting, plus:

- **A scope section specific to `kir`.** The generic "report vulnerabilities here" template would miss the point: the interesting class for this tool is *silent under-reporting*, because an omitted image is indistinguishable from a manifest that had none. That's stated first, ahead of the conventional resource-exhaustion and release-integrity items.
- **An explicit out-of-scope line** for malformed input producing `error:` and a non-zero exit, pointing at ADR 0008 — otherwise that gets reported as a bug repeatedly.
- **Supported versions**, reflecting how release-please actually works here: pre-1.0, roll forward, no maintenance branches.
- **A pointer to the existing cosign verification steps** in `CONTRIBUTING.md`, so the signing work the project already did is discoverable from the security policy.

No response-time commitment, since that would be a promise the project can't keep.

## One thing to check before merging

The report link (`/security/advisories/new`) only works if **Private vulnerability reporting** is enabled under Settings → Code security. If it isn't, the link 404s for reporters. I can't see repository settings, so please confirm it's on — it's a single toggle.

## Verification

- Both relative links resolve: `CONTRIBUTING.md` and `docs/adr/0008-best-effort-processing-and-exit-codes.md`.
- The `#verifying-a-release` anchor matches the real `### Verifying a release` heading at `CONTRIBUTING.md:61`.
- Documentation only — no code or workflow changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cabg1eqYp3Kx3wcf8gxRc8)_