### PR TITLE
feat(release): attest build provenance for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
       contents: write # upload release assets
       packages: write # push image to GHCR
       id-token: write # cosign keyless signing
+      attestations: write # record build provenance
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -77,3 +78,13 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # The cosign signature over checksums.txt establishes who published a
+      # release; provenance establishes how it was built — which workflow, from
+      # which commit, on which runner. Subjects are read from checksums.txt so
+      # the attestation covers exactly the artifacts the signature already
+      # covers, and cannot drift from them.
+      - name: Attest build provenance for the release artifacts
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-checksums: dist/checksums.txt


### PR DESCRIPTION
One of the provenance fixes from a security review of `kir`. Independent of the others.

## Problem

The release is signed keylessly with cosign, which proves **who** published it — the identity is this repository's workflow. It says nothing about **how** it was built: which workflow file, from which commit, on which runner, with which inputs. Someone verifying `checksums.txt.sigstore.json` today learns the artifacts came out of this repo's release job; they can't check that the job built them from the tagged source.

That's the gap SLSA provenance fills, and it composes with the keyless setup already here — same OIDC token, same Sigstore backend.

## Change

Adds `attestations: write` to the `goreleaser` job and one step after GoReleaser:

```yaml
      - name: Attest build provenance for the release artifacts
        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
        with:
          subject-checksums: dist/checksums.txt
```

**`subject-checksums` rather than a glob over `dist/`** is the deliberate bit. A glob would need maintaining as `.goreleaser.yaml`'s `archives` change, and could silently cover more or less than the signature does. Reading the subjects out of `checksums.txt` means the attestation and the existing cosign signature cover exactly the same set by construction.

Consumers verify with `gh attestation verify <archive> --repo MPV/kir`.

## Scope

Binaries and archives only. The container image needs its subject identified by digest instead of by file, which is a different mechanism — worth doing, but as its own change rather than bolted onto this one.

## Verification

- Ran GoReleaser locally to produce a real `dist/checksums.txt` (`goreleaser release --snapshot --clean --skip=publish,sign,docker,sbom`), then checked the format the action has to parse: 6 lines, all `sha256hex  filename`, covering every archive in the matrix (darwin/linux/windows × amd64/arm64). Confirmed 0 malformed lines.
- `actionlint` clean; parsed the workflow and confirmed the permissions block and the step's inputs resolve as intended.
- Confirmed `4d101475…` really is `v4.2.2` via `git ls-remote --tags`, and read the action's `action.yml` at that SHA to confirm `subject-checksums` exists and what it expects.

**Not verified:** the attestation step itself never ran — it needs a real release, an OIDC token, and artifacts pushed to a GitHub Release, none of which exist outside the release workflow. What I could check offline is that the input the step consumes is well-formed and complete.

## Merge order

This and the image-SBOM PR both append a step to the `goreleaser` job and both touch its `permissions` block, so whichever lands second will need a trivial rebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cabg1eqYp3Kx3wcf8gxRc8)_