### PR TITLE
feat(release): attest an SBOM for the published container image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,3 +93,38 @@ jobs:
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-checksums: dist/checksums.txt
+
+      # GoReleaser's `sboms` block cannot cover an image — its `artifacts`
+      # field accepts source, package, archive, binary, any or none, with no
+      # image target — so the released image gets its SBOM here instead.
+      #
+      # The attestation is attached by digest, read back from the registry
+      # rather than assumed from the tag, so it is bound to the exact manifest
+      # GoReleaser just pushed.
+      - name: Attest an SBOM for the published image
+        env:
+          IMAGE_REPO: mpv/kir
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG_NAME#v}"
+
+          token="$(curl -fsSL \
+            "https://ghcr.io/token?service=ghcr.io&scope=repository:${IMAGE_REPO}:pull" \
+            | jq -r .token)"
+          digest="$(curl -fsSL -o /dev/null -D- \
+            -H "Authorization: Bearer ${token}" \
+            -H "Accept: application/vnd.oci.image.index.v1+json" \
+            "https://ghcr.io/v2/${IMAGE_REPO}/manifests/${version}" \
+            | awk -F': ' 'tolower($1) == "docker-content-digest" { gsub(/\r/, ""); print $2 }')"
+
+          if [ -z "${digest}" ]; then
+            echo "could not resolve a digest for ghcr.io/${IMAGE_REPO}:${version}" >&2
+            exit 1
+          fi
+          echo "attesting SBOM for ghcr.io/${IMAGE_REPO}@${digest}"
+
+          syft "ghcr.io/${IMAGE_REPO}:${version}" -o spdx-json > sbom.spdx.json
+          cosign attest --yes --type spdx \
+            --predicate sbom.spdx.json \
+            "ghcr.io/${IMAGE_REPO}@${digest}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,9 @@ jobs:
           echo "attesting SBOM for ghcr.io/${IMAGE_REPO}@${digest}"
 
           syft "ghcr.io/${IMAGE_REPO}:${version}" -o spdx-json > sbom.spdx.json
-          cosign attest --yes --type spdx \
+          # spdxjson, not spdx: both carry the SPDX predicate type, but `spdx`
+          # embeds the document as an opaque string while `spdxjson` parses it,
+          # so consumers get a structured SBOM rather than JSON in a string.
+          cosign attest --yes --type spdxjson \
             --predicate sbom.spdx.json \
             "ghcr.io/${IMAGE_REPO}@${digest}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,34 @@ Then check a downloaded binary's archive against `checksums.txt`. The container
 image is signed too: `cosign verify ghcr.io/mpv/kir:X.Y.Z` (with the same
 identity flags).
 
+The image also carries its SBOM as a signed attestation. Verifying it checks the
+same keyless identity as the signature above, and additionally that the SBOM was
+produced by the release workflow rather than supplied by whoever handed you the
+image:
+
+```shell
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp 'https://github.com/mpv/kir/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/mpv/kir:X.Y.Z
+```
+
+To read the SBOM itself, unwrap the in-toto payload from the verified
+attestation:
+
+```shell
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp 'https://github.com/mpv/kir/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/mpv/kir:X.Y.Z \
+  | jq -r '.payload | @base64d | fromjson | .predicate' > kir.spdx.json
+```
+
+Release archives don't need this: their SBOMs are published as separate files
+alongside the checksums, so they can be read directly.
+
 Dependency updates are managed by [Renovate](https://docs.renovatebot.com/),
 which follows the same commit conventions, so routine bumps flow through the same
 process.


### PR DESCRIPTION
Publishes an SBOM for the released container image, as a signed attestation, and documents how to verify it. Rebased on top of the merged provenance step (#91).

## Problem

`.goreleaser.yaml` produces SBOMs for release archives:

```yaml
sboms:
  - artifacts: archive
```

but not for the image, and it can't: GoReleaser's schema restricts `sboms[].artifacts` to `source`, `package`, `archive`, `binary`, `any` and `none` — there is no image target. So someone pulling `ghcr.io/mpv/kir:X.Y.Z` gets a cosign signature but no bill of materials, while someone downloading the tarball gets both.

## Change

Two commits.

**1. Attach the SBOM** (`ci:`) — one step after GoReleaser, using the `syft` and `cosign` the workflow already installs:

```bash
version="${TAG_NAME#v}"
token="$(curl -fsSL ".../token?...scope=repository:${IMAGE_REPO}:pull" | jq -r .token)"
digest="$(curl -fsSL -o /dev/null -D- ... | awk -F': ' 'tolower($1) == "docker-content-digest" { ... }')"
syft "ghcr.io/${IMAGE_REPO}:${version}" -o spdx-json > sbom.spdx.json
cosign attest --yes --type spdxjson --predicate sbom.spdx.json "ghcr.io/${IMAGE_REPO}@${digest}"
```

Attached **by digest, not tag**: `cosign attest` against a tag warns and races, since the tag could move between GoReleaser pushing it and cosign resolving it. Reading `Docker-Content-Digest` back from the registry binds the attestation to the manifest that was just pushed. `IMAGE_REPO` is hardcoded lowercase rather than `${{ github.repository }}` (which is `MPV/kir`, and GHCR paths are lowercase); values from workflow outputs go through `env:` rather than into the script body.

**`--type spdxjson`, not `spdx`.** Both carry the same SPDX predicate type URI, so either appears to work, but they embed the predicate differently ([`generateSPDXStatement`](https://github.com/sigstore/cosign/blob/v2.6.5/pkg/cosign/attestation/attestation.go#L272)):

```go
	if parseJSON {
		if err := json.Unmarshal(rawPayload, &data); err != nil { ... }
	} else {
		data = string(rawPayload)   // <- what --type spdx does
	}
```

`spdx` sets `parseJSON=false` and stuffs the whole document into the predicate as one quoted string. Since `syft -o spdx-json` emits JSON, `spdxjson` is the correct type and gives consumers a structured document.

**2. Document verifying it** (`docs:`) — `CONTRIBUTING.md`'s "Verifying a release" gains a `cosign verify-attestation` example and a one-liner that unwraps the in-toto payload into a readable `kir.spdx.json`. Without it the attestation exists but nobody knows to look for it.

## Upstream status

Checked whether GoReleaser has this pending, so we could defer to it. Short answer: **nothing to defer to, but there is something to plan for.**

[goreleaser#2997](https://github.com/goreleaser/goreleaser/issues/2997) — "create an SBOM attestations using syft and attach them to container image using cosign" — is the request for exactly this approach. It is **closed as not planned**. So the syft+cosign path is not coming natively.

What *is* coming is different. `dockers_v2` — the replacement for the `dockers`/`docker_manifests` blocks this repo uses — has a native `sbom` option, **on by default**. Verified against the v2.17.1 source rather than the docs (`goreleaser.com` is unreachable from where I checked):

```go
// internal/pipe/docker/v2/docker.go
extraArgs := []string{"--push"}
if sbom {
	extraArgs = append(extraArgs, "--attest=type=sbom")
}
```

with `if docker.SBOM == "" { docker.SBOM = "true" }` in the defaults.

So it produces a **BuildKit attestation in the image index**, not a cosign attestation. That's a different artifact, not a drop-in replacement for this step:

| | this PR | `dockers_v2: sbom` |
| --- | --- | --- |
| Producer | syft | BuildKit's own scanner |
| Storage | cosign attestation | attestation manifest in the image index |
| Signature | keyless, DSSE-wrapped | none over the SBOM itself |
| Verified with | `cosign verify-attestation` | `docker buildx imagetools inspect --format '{{json .SBOM}}'` |

`goreleaser check` on this config already says `dockers` and `docker_manifests` "are being phased out and will eventually be replaced by `dockers_v2`", so that migration is coming regardless — and it's a bigger change than this PR. When it happens, this step is worth revisiting: drop it for the BuildKit attestation, or keep it if the keyless-signed SPDX that `CONTRIBUTING.md` documents is worth more than one fewer moving part. One thing that won't block it — `dockers_v2` warns unless buildx uses the `docker-container` driver, and `docker/setup-buildx-action` already defaults to exactly that.

## Verification

- Extracted the `run:` block from the committed YAML and **executed it** with `syft`/`cosign` stubbed and `TAG_NAME=v0.4.3`, against the really-published image. It resolved `ghcr.io/mpv/kir@sha256:d9afa86e26c494e6e465b89efa172fee9d8473a64a3f89277704b36e78a1dbd2` and produced the intended invocations — so the token fetch, digest parse, `v`-prefix stripping, quoting and `set -euo pipefail` behaviour are confirmed against the real registry.
- Built cosign v2.6.5 and confirmed from `verify-attestation --help` that `--type`, `--certificate-identity-regexp` and `--certificate-oidc-issuer` exist and that `spdxjson` is an accepted `--type`.
- Ran the documented `jq -r '.payload | @base64d | fromjson | .predicate'` pipeline against a hand-built DSSE envelope containing a real in-toto statement; it extracted the SPDX predicate cleanly.
- `bash -n` over every shell block in the new docs section; `actionlint` clean; `goreleaser schema` confirms `sboms[].artifacts` has no image option.

**Not verified:** `syft` and `cosign` were stubbed, so SBOM generation and the attestation upload have not themselves run — both need a real release and an OIDC token. The documented `verify-attestation` command likewise can't run until an attestation exists, so its flags are confirmed to exist but the round trip isn't.