### PR TITLE
build: make a failing golden readable and approvable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@ file is the short version of what trips agents up.
   checked-in `.yaml`, which tooling silently normalises.
 - Run before opening a PR: `make test`, `go vet ./...`, `gofmt -l .` (empty),
   `go test -race ./...`.
+- Intended output changes: `make test` prints received vs approved for each
+  failure, `make approve` accepts them. Read the diff first and describe it in
+  the PR body — a golden diff **is** the behaviour change, so never approve one
+  just to clear a red test.
 
 ## Commits & PRs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,27 @@ gofmt -l .   # should print nothing
 CI runs `gofmt`, `go vet`, `go mod tidy` verification, and `go test -race`, so
 run them locally before opening a pull request.
 
+## Approving changed golden output
+
+Behaviour is pinned by approval tests (ADR 0004/0005), so a change to what `kir`
+prints shows up as failing goldens. A failing test leaves what it produced beside
+its golden as `*.received.txt` and `make test` prints both files' contents; a
+passing test deletes its own received file. When the new output is what you
+meant:
+
+```shell
+make test      # prints received vs approved for each failure
+make approve   # renames every *.received.txt over its *.approved.txt
+```
+
+`make approve` accepts every received file it finds, so run it after a full
+`make test` — a filtered `go test -run ...` leaves the untouched tests' files
+behind.
+
+Read the output before approving. A golden diff *is* the behaviour change, so it
+belongs in the pull request description; approving one to clear a red test hides
+the very thing review needs to see.
+
 ## Architecture decisions
 
 Design decisions are recorded as ADRs in [`docs/adr/`](docs/adr/). Read them

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,16 @@ build:
 # setting: GitHub Actions sets CI=true, which selects an equivalent reporter.
 test:
 	APPROVAL_TESTS_USE_REPORTER=SystemoutReporter go test ./... -v
+
+# Accept the current output as the goldens. A failing approval test leaves what
+# it produced beside its golden as *.received.txt; a passing one deletes its own,
+# so the files left over are exactly the failures. Read what `make test` printed
+# before running this, and run it after a full `make test` — a filtered
+# `go test -run ...` leaves other tests' received files behind, and this accepts
+# every one it finds.
+approve:
+	@for f in approvals/*.received.txt; do \
+		[ -e "$$f" ] || continue; \
+		mv "$$f" "$${f%.received.txt}.approved.txt"; \
+		echo "approved $$(basename $${f%.received.txt})"; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 build:
 	go build -o bin/ ./...
 
+# go-approval-tests dropped its console reporter in v1.13.0, so a failing golden
+# now reports only "received does not match approved" — no diff, no file names.
+# The Systemout reporter prints both files and their contents. CI needs no such
+# setting: GitHub Actions sets CI=true, which selects an equivalent reporter.
 test:
-	go test ./... -v
+	APPROVAL_TESTS_USE_REPORTER=SystemoutReporter go test ./... -v


### PR DESCRIPTION
Follow-up to the `go-approval-tests` v1.14.0 bump (#24). Two Makefile targets, no test or production code touched.

## 1. A failing golden says nothing (`build: print the approval diff on a failed golden`)

v1.13.0 removed the reporter that printed the diff, so since #24 landed, `make test` — the command CONTRIBUTING.md and AGENTS.md tell every contributor to run before a PR — reports a golden failure like this:

```
Finding JetBrains IDE...
    kir_test.go:49: Failed Approval: received does not match approved.
```

No file names, no contents. v1.14.0 added `APPROVAL_TESTS_USE_REPORTER`; pointing it at the Systemout reporter restores a usable failure. Same broken golden, after:

```
approval files did not match
approved: .../kir_test.TestKind.Pod.stdout.approved.txt
received: .../kir_test.TestKind.Pod.stdout.received.txt
Received content:
nginx
gcr.io/google-containers/sidecar
busybox:1.28

Approved content:
wrong:image
```

CI is deliberately untouched: it runs `go test -race ./...` directly, and GitHub Actions sets `CI=true`, which already selects an equivalent reporter. (`ContinuousIntegrationReporter` is *not* the name to use outside CI — it no-ops unless it detects a CI environment and lets auto-detection take over.)

## 2. Nothing documented how to approve one (`build: add make approve`)

There were no instructions anywhere for updating a golden. That is how the newline change got approved: seventeen received files moved one at a time.

`go-approval-tests` ships `approve_all.py` for this, but it is the wrong thing to point contributors at — it is fetched from `raw.githubusercontent.com` by a fire-and-forget goroutine racing process exit, so whether it exists depends on how long the run took. From a wiped `.approval_tests_temp`:

| command | duration | result |
|---|---|---|
| `go test ./approvals/` | ~0.02s | logs only, **no scripts** |
| `go test -race ./approvals/` | ~1s | scripts present |

Its download path also fails silently by design, so offline it never arrives. A make target is deterministic, needs no network or Python, and sits beside the `make test` that produced the files.

Wholesale renaming is safe because a passing test deletes its own received file (`approvals.go`: `_ = os.Remove(receivedFile)`), so what remains after a full run is exactly the failures. That does not hold after a filtered `go test -run ...`, which is called out in both the Makefile comment and CONTRIBUTING.md.

## Verification

- `make approve` is a no-op when nothing failed (exit 0, no output).
- With `kir_test.TestKind.Pod.stdout` and `kir_test.TestList.exitcode` deliberately broken, `make test && make approve` restores both and the suite passes.
- `make test`, `go vet ./...`, `gofmt -l .` (empty), `go test -race ./...` all pass.

Both commits are `build:`, so neither cuts a release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBt5arMEZnxpjgh3GREnri)_