### PR TITLE
ci: build releases with the Go version CI tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,15 @@ jobs:
           ref: ${{ needs.release-please.outputs.tag_name }}
           fetch-depth: 0
 
+      # .tool-versions, not go.mod: go.mod's `go` directive is the minimum
+      # language version the module needs — dependencies raise it, and it is not
+      # a statement about which toolchain to build with. Reading .tool-versions
+      # means releases are built with the same Go the Test workflow checks, so
+      # what CI verifies and what ships cannot drift apart.
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: go.mod
+          go-version-file: .tool-versions
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0


### PR DESCRIPTION
Makes the release build use the same Go version the Test workflow verifies.

## Problem

The two workflows take the Go version from different files:

| Workflow | Source | Resolves to |
| --- | --- | --- |
| `test.yml` | `.tool-versions` | 1.26.5 |
| `release.yml` | `go-version-file: go.mod` | 1.26.0 |

`go.mod`'s `go` directive is the minimum language version the module requires. Dependencies raise it — it reads `1.26.0` because k8s v0.36.3 needs that — so it isn't a choice about which toolchain to build with. Using it means the published binaries are built with a Go that CI never exercised.

Where that bites: govulncheck attributes standard-library advisories to the toolchain it analyses. Scanning one Go version while shipping another lets an advisory fixed between the two pass unreported — a green check describing a binary nobody built.

Both files currently sit on 1.26.x, so no advisory is slipping through today. This removes the way it could.

## Change

```diff
-          go-version-file: go.mod
+          go-version-file: .tool-versions
```

`setup-go` reads `.tool-versions` natively, so no version-derivation step is needed here. `.tool-versions` becomes the single source of truth for the toolchain, and `go.mod`'s directive goes back to meaning only what it's for.

## Verification

- `.tool-versions` is a supported `go-version-file` input for the pinned `setup-go` — confirmed in its `action.yml` at `b7ad1dad` (v7.0.0), not from docs for another version.
- The parser matches this file: `setup-go`'s bundled `dist/setup/index.js` uses `/golang\s+([^\n#]+)/m`, and `.tool-versions` is `golang 1.26.5`. Ran that regex against the real file — resolves to `1.26.5`.
- `actionlint` clean.

Not verified: `release.yml` runs only on a release, so this hasn't executed. The change is one input value whose parse is confirmed against the pinned action's own code.

## Note for the merge

This changes what ships — released binaries get built with 1.26.5 instead of 1.26.0. The `ci:` prefix cuts no release; retitle to `fix:` when squash-merging if you want it to reach users promptly.