### PR TITLE
build: migrate image publishing to dockers_v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,39 +37,30 @@ checksum:
 sboms:
   - artifacts: archive
 
-dockers:
-  - image_templates:
-      - "ghcr.io/mpv/kir:{{ .Version }}-amd64"
-    use: buildx
-    goarch: amd64
+# One `docker buildx build --platform linux/amd64,linux/arm64 --push` produces
+# the multi-arch index directly, replacing the per-arch `dockers` entries and
+# the `docker_manifests` that stitched them together (both of which GoReleaser
+# is phasing out). Binaries are staged into the build context under
+# <platform>/<name>, which is why Dockerfile.goreleaser copies from
+# ${TARGETPLATFORM}.
+dockers_v2:
+  - images:
+      - "ghcr.io/mpv/kir"
+    tags:
+      - "{{ .Version }}"
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
     dockerfile: Dockerfile.goreleaser
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.source=https://github.com/mpv/kir"
-  - image_templates:
-      - "ghcr.io/mpv/kir:{{ .Version }}-arm64"
-    use: buildx
-    goarch: arm64
-    dockerfile: Dockerfile.goreleaser
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.source=https://github.com/mpv/kir"
-
-docker_manifests:
-  - name_template: "ghcr.io/mpv/kir:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/mpv/kir:{{ .Version }}-amd64"
-      - "ghcr.io/mpv/kir:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/mpv/kir:latest"
-    image_templates:
-      - "ghcr.io/mpv/kir:{{ .Version }}-amd64"
-      - "ghcr.io/mpv/kir:{{ .Version }}-arm64"
+    # Adds a BuildKit SBOM attestation to the image index (--attest=type=sbom).
+    # This is GoReleaser's default; stated explicitly so it can't change under us.
+    sbom: true
+    labels:
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.source: "https://github.com/mpv/kir"
 
 # Keyless (Sigstore) signing of the checksums file — one bundle (.sigstore.json)
 # covers every binary/archive. See CONTRIBUTING.md for how to verify a release.
@@ -84,7 +75,9 @@ signs:
     artifacts: checksum
     output: true
 
-# Keyless (Sigstore) signing of the published multi-arch image manifests.
+# Keyless (Sigstore) signing of the published image index. `artifacts:
+# manifests` selects both docker_manifests and dockers_v2 artifacts, so this
+# still signs every pushed tag after the dockers_v2 migration.
 docker_signs:
   - cmd: cosign
     args:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,7 +1,12 @@
-# Build context is assembled by GoReleaser: the pre-built `kir` binary for the
-# target platform is copied in, so there is no build step here.
+# Build context is assembled by GoReleaser: the pre-built `kir` binary for each
+# target platform is staged under <platform>/kir (e.g. linux/amd64/kir), so there
+# is no build step here.
 FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
 WORKDIR /
-COPY kir /kir
+# TARGETPLATFORM is set per-platform by buildx. Copying through it — rather than
+# naming an architecture — is what keeps each image in the index holding its own
+# binary; a hardcoded path would silently ship one architecture everywhere.
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/kir /kir
 USER 65532:65532
 ENTRYPOINT ["/kir"]


### PR DESCRIPTION
**Draft deliberately — I could not exercise the build.** See "Why this is a draft" before merging; it's the whole point of the PR.

## What it does

`goreleaser check` on `master` reports:

> `dockers` and `docker_manifests` are being phased out and will eventually be replaced by `dockers_v2`

This migrates. Two per-arch `dockers` entries plus two `docker_manifests` become one `dockers_v2` entry: a single `docker buildx build --platform linux/amd64,linux/arm64 --push` publishes the multi-arch index directly, instead of building two single-arch images and stitching them together afterwards. Net −36/+34 lines.

`Dockerfile.goreleaser` changes because the build context changes. `dockers_v2` stages each platform's binary under `<platform>/<name>`, so:

```dockerfile
ARG TARGETPLATFORM
COPY ${TARGETPLATFORM}/kir /kir
```

Copying through `TARGETPLATFORM` rather than naming an architecture is what keeps each image in the index holding its own binary — a hardcoded path would build fine and silently ship one architecture everywhere.

## Behavioural changes

**Per-arch tags stop being pushed.** `ghcr.io/mpv/kir:X.Y.Z-amd64` and `-arm64` existed only as inputs to `docker_manifests`; `dockers_v2` has no equivalent intermediate. If anyone pulls those directly it breaks for them, so you may want a stronger commit type than the `build:` I used.

**`sbom: true` adds a BuildKit SBOM attestation** to the image index (`--attest=type=sbom`). That's GoReleaser's default — `if docker.SBOM == "" { docker.SBOM = "true" }` — set explicitly here so it can't change under us. Note this is a *different artifact* from #92's cosign attestation: BuildKit's own scanner, stored in the index, unsigned. It doesn't replace #92, and the two can coexist; the table in #92 lays out the difference.

**Signing is unaffected**, which was the thing I most wanted to confirm before proposing this. `docker_signs` with `artifacts: manifests` maps to `ByTypes(DockerManifest, DockerImageV2)`, so `dockers_v2` artifacts are still signed and every pushed tag keeps its keyless signature.

## Verified

Everything below is against the GoReleaser the release workflow would resolve (`~> v2` → v2.17.1), read from source rather than the docs — `goreleaser.com` is unreachable from where I work:

- `goreleaser check` passes and **the deprecation warning is gone**.
- Config parses to the intended shape: `dockers` and `docker_manifests` absent, `images × tags` = the four refs, `sboms: [{artifacts: archive}]` untouched.
- `sbom: true` → `--attest=type=sbom` (`internal/pipe/docker/v2/docker.go`, `extraArgs`).
- `docker_signs` covers `DockerImageV2` (`internal/pipe/sign/sign_docker.go:60-77`).
- The context layout my `COPY` depends on: `toPlatform` returns `path.Join("linux","amd64")`, and upstream's own test asserts `linux/amd64/mybin` and `linux/arm/v7/mybin` exist in the context dir. So `${TARGETPLATFORM}/kir` is correct for both platforms here.
- `dockers_v2` warns unless buildx uses the `docker-container` driver; `docker/setup-buildx-action` defaults to exactly that (checked its `action.yml` at the pinned SHA), so the workflow already satisfies it.

## Why this is a draft

**I never ran the build.** `dockers_v2` is a publisher and always passes `--push`, so there is no `--snapshot` path that builds images without pushing them. I tried to verify locally against a throwaway registry: a Docker daemon starts in my environment, but image pulls are blocked by its egress proxy, so buildkit can't bootstrap.

That matters more here than on the other PRs in this series. This is the only code path that publishes signed release artifacts, it runs *only* on a real release, and a failure lands **after** release-please has already cut the tag and GitHub Release — so a bad merge means a released version with no image, discovered at the worst moment.

So I'd want one of these before it's merged, not after:

1. **A one-off dry run.** Run GoReleaser from this branch against a throwaway tag — `dockers_v2.images: ghcr.io/mpv/kir-dryrun`, say — and confirm: the index lists exactly `linux/amd64` and `linux/arm64`; the binary inside each is that architecture (`docker run --platform=linux/arm64 … kir --version`, or pull each and `file` it); the four OCI labels are present; `docker buildx imagetools inspect --format '{{json .SBOM}}'` returns something; and `cosign verify` still passes on the pushed tags.
2. **Or a temporary `workflow_dispatch` job** doing the same inside CI, which has the driver and credentials already. Happy to write either — say which and I'll raise it.

The architecture check is the one I'd least want skipped. It's the failure this change makes possible that nothing else in the pipeline would catch.

## Sequencing

After #92. That one is small, additive and verified; this one deliberately isn't yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cabg1eqYp3Kx3wcf8gxRc8)_